### PR TITLE
feat: add countdown timer to clues with time-based scoring in True Network attestations.

### DIFF
--- a/frontend/acm/assembly/attestations.ts
+++ b/frontend/acm/assembly/attestations.ts
@@ -14,12 +14,14 @@ class HUNTATTESTATIONSCHEMA {
   numberOfTries: u32;
   huntId: u32;
   clueNumber: u32;
+  timeTaken: u32;
 
   constructor() {
     this.timestamp = readMemory<u64>(0);
     this.numberOfTries = readMemory<u32>(8);
     this.huntId = readMemory<u32>(12);
     this.clueNumber = readMemory<u32>(16);
+    this.timeTaken = readMemory<u32>(20);
   }
 }
 

--- a/frontend/acm/assembly/index.ts
+++ b/frontend/acm/assembly/index.ts
@@ -11,6 +11,7 @@ export function calc(): i64 {
   // Access attestation values directly
   const currentTries = huntAttestation.numberOfTries;
   const currentTimestamp = huntAttestation.timestamp;
+  const currentTimeTaken = huntAttestation.timeTaken;
 
   // Track the latest timestamp
   if (currentTimestamp > latestTimestamp) {
@@ -23,13 +24,27 @@ export function calc(): i64 {
   // Base points for completing clue (max 100)
   attestationScore += 100;
 
-  // Efficiency points based on tries (max 50)
+  // Efficiency points based on tries (max 40)
   if (currentTries == 1) {
-    attestationScore += 50; // Perfect solve
+    attestationScore += 40; // Perfect solve
   } else if (currentTries == 2) {
-    attestationScore += 25; // Good solve
+    attestationScore += 20; // Good solve
   } else if (currentTries == 3) {
-    attestationScore += 10; // Regular solve
+    attestationScore += 8; // Regular solve
+  }
+
+  // Time efficiency points based on time taken (max 30)
+  // Assuming optimal time is 60 seconds, with diminishing returns
+  if (currentTimeTaken <= 60) {
+    attestationScore += 30; // Excellent time
+  } else if (currentTimeTaken <= 120) {
+    attestationScore += 20; // Good time
+  } else if (currentTimeTaken <= 300) {
+    attestationScore += 10; // Average time
+  } else if (currentTimeTaken <= 600) {
+    attestationScore += 5; // Slow but acceptable
+  } else {
+    attestationScore += 1; // Very slow but still completed
   }
 
   // Add to running totals
@@ -41,9 +56,9 @@ export function calc(): i64 {
     return 0;
   }
 
-  // Calculate average score per clue (out of 150 possible points per clue)
+  // Calculate average score per clue (out of 170 possible points per clue: 100 base + 40 tries + 30 time)
   // Multiply by 10 first to maintain precision in integer division
-  const averageScore: i64 = (totalScore * 10) / (totalClues * 150);
+  const averageScore: i64 = (totalScore * 10) / (totalClues * 170);
 
   // Apply time decay factor to encourage continued participation
   // Reduce score by 10% for every 30 days of inactivity

--- a/frontend/src/components/Clue.tsx
+++ b/frontend/src/components/Clue.tsx
@@ -42,6 +42,8 @@ export function Clue() {
     "idle" | "verifying" | "success" | "error"
   >("idle");
   const [showSuccessMessage, setShowSuccessMessage] = useState(false);
+  const [timeLeft, setTimeLeft] = useState<number | null>(null);
+  const [elapsedSeconds, setElapsedSeconds] = useState<number>(0);
 
   // Add this to get current network from localStorage
   const currentNetwork = localStorage.getItem("current_network") || "assetHub";
@@ -92,6 +94,39 @@ export function Clue() {
         }
       );
     }
+
+    // Initialize or restore per-clue timer start
+    const clueTimerKey = `hunt_${huntId}_clue_${clueId}_start`;
+    const storedStart = localStorage.getItem(clueTimerKey);
+    const startTimestamp = storedStart ? Number(storedStart) : Date.now();
+    if (!storedStart) {
+      localStorage.setItem(clueTimerKey, String(startTimestamp));
+    }
+
+    // Compute per-clue duration from hunt duration if available
+    const totalDurationSeconds = huntDetails ? Number(huntDetails[3] ?? 0) : 0;
+    const riddles = JSON.parse(
+      localStorage.getItem(`hunt_riddles_${huntId}`) || "[]"
+    );
+    const totalClues = Array.isArray(riddles) ? riddles.length : 0;
+    const perClueDuration = totalClues > 0 && totalDurationSeconds > 0
+      ? Math.max(1, Math.floor(totalDurationSeconds / totalClues))
+      : 0;
+
+    // Tick every second
+    const tick = () => {
+      const now = Date.now();
+      const elapsed = Math.floor((now - startTimestamp) / 1000);
+      setElapsedSeconds(elapsed);
+      if (perClueDuration > 0) {
+        setTimeLeft(Math.max(0, perClueDuration - elapsed));
+      } else {
+        setTimeLeft(null);
+      }
+    };
+    tick();
+    const interval = setInterval(tick, 1000);
+    return () => clearInterval(interval);
   }, [clueId, huntId, navigate]);
 
   if (!isValidHexAddress(contractAddress)) {
@@ -128,6 +163,7 @@ export function Clue() {
         timestamp: Math.floor(Date.now() / 1000), // Current timestamp in seconds
         clueNumber: parseInt(clueId || "0"),
         numberOfTries: attempts,
+        timeTaken: elapsedSeconds,
       });
       console.log("Attestation created:", output);
       await api.network.disconnect();
@@ -325,6 +361,11 @@ export function Clue() {
               <div className="text-2xl font-bold">
                 # {currentClue}/{currentClueData?.length}
               </div>
+              {timeLeft !== null && (
+                <div className="text-xl font-mono">
+                  {`${String(Math.floor(timeLeft / 60)).padStart(2, "0")}:${String(timeLeft % 60).padStart(2, "0")}`}
+                </div>
+              )}
             </div>
 
             <h1 className="text-xl font-bold mb-2">{huntData?.title}</h1>
@@ -359,7 +400,8 @@ export function Clue() {
                 disabled={
                   !location ||
                   verificationState === "verifying" ||
-                  verificationState === "success"
+                  verificationState === "success" ||
+                  (timeLeft !== null && timeLeft <= 0)
                 }
               >
                 {verificationState === "success" && (

--- a/frontend/src/schemas/huntSchema.ts
+++ b/frontend/src/schemas/huntSchema.ts
@@ -1,8 +1,11 @@
 import { Schema, U32, U64 } from "@truenetworkio/sdk";
 
+// Note: Field order chosen to maintain stable offsets for existing fields.
+// timestamp (u64) at 0, numberOfTries (u32) at 8, huntId (u32) at 12, clueNumber (u32) at 16, timeTaken (u32) at 20
 export const huntAttestationSchema = Schema.create({
-  huntId: U32,
   timestamp: U64,
-  clueNumber: U32,
   numberOfTries: U32,
+  huntId: U32,
+  clueNumber: U32,
+  timeTaken: U32,
 });


### PR DESCRIPTION
This PR implements a per-clue countdown timer that splits the hunt's total duration across all clues, displays remaining time prominently at the top of each clue, and includes timeTaken in True Network attestations for enhanced scoring.
The algorithm now considers both efficiency (attempts used) and speed (time taken) when calculating user trust scores, with appropriate weighting for each factor in the reputation system.