### PR TITLE
bug: Disable Upload to IPFS button for re-uploads

### DIFF
--- a/frontend/src/components/Create.tsx
+++ b/frontend/src/components/Create.tsx
@@ -900,11 +900,11 @@ export function Create() {
                   {clues.length > 0 && (
                     <Button
                       onClick={uploadToIPFS}
-                      disabled={isUploading}
+                      disabled={isUploading || (cluesCID !== "" && answersCID !== "")}
                       variant="outline"
                       className="bg-green-50"
                     >
-                      {isUploading ? "Uploading..." : "Upload Clues to IPFS"}
+                      {isUploading ? "Uploading..." : (cluesCID && answersCID) ? "Already Uploaded" : "Upload Clues to IPFS"}
                     </Button>
                   )}
                 </div>


### PR DESCRIPTION
Disable the "Upload to IPFS" button and update its text when clues and answers are already uploaded to prevent redundant uploads and improve user experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-ee998cd5-a3b0-42b0-addb-36af9bef8c6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ee998cd5-a3b0-42b0-addb-36af9bef8c6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

Closes #204 

