### PR TITLE
feat: Neobrutalism themed toasts

### DIFF
--- a/frontend/src/components/Clue.tsx
+++ b/frontend/src/components/Clue.tsx
@@ -20,7 +20,7 @@ import { useReadContract, useActiveAccount } from 'thirdweb/react';
 import { getContract } from 'thirdweb';
 import { huntABI } from '../assets/hunt_abi';
 import { useNetworkState } from '../lib/utils';
-import { toast } from 'sonner';
+import { toast } from '@/components/ui/toast';
 import { client } from '../lib/client';
 import { Hunt, Team, HUNT_TYPE, enumToHuntType, HuntType } from '../types';
 import {

--- a/frontend/src/components/Create.tsx
+++ b/frontend/src/components/Create.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef } from "react";
 import { useActiveAccount } from "thirdweb/react";
 import { huntABI } from "../assets/hunt_abi";
-import { toast } from "sonner";
+import { toast } from "@/components/ui/toast";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";

--- a/frontend/src/components/HuntDetails.tsx
+++ b/frontend/src/components/HuntDetails.tsx
@@ -17,7 +17,7 @@ import { HuddleRoom } from "./HuddleRoom";
 import { useReadContract, useActiveAccount, useSendTransaction } from "thirdweb/react";
 import { getContract, prepareContractCall, readContract } from "thirdweb";
 import { useNetworkState } from "../lib/utils";
-import { toast } from "sonner";
+import { toast } from "@/components/ui/toast";
 import { client } from "../lib/client";
 import QRCode from "react-qr-code";
 import QrScanner from "qr-scanner";
@@ -590,7 +590,7 @@ export function HuntDetails() {
           
           try {
             console.log("⏳ Extracting teamId from transaction logs...");
-            const waitToastId = toast.loading("Getting transaction receipt and doing the magic...");
+            toast.loading("Getting transaction receipt and doing the magic...");
             
             // Extract teamId from transaction logs
             const teamId = await extractTeamIdFromTransactionLogs(
@@ -600,7 +600,8 @@ export function HuntDetails() {
             );
 
             // Success! We have the teamId from the logs
-            toast.success("Generating invite...", { id: waitToastId });
+            toast.dismiss(); // Dismiss the loading toast
+            toast.success("Generating invite...");
             await generateInviteAfterTeamCreation(teamId);
             // Refetch again after invite generation
             refetchTeamData();
@@ -611,7 +612,7 @@ export function HuntDetails() {
             
             // Fallback to the original method if parsing logs fails
             try {
-              const waitToastId = toast.loading("Its taking longer than expected...");
+              toast.loading("Its taking longer than expected...");
               
               const getTeamIdOperation = async (): Promise<string> => {
                 console.log("🔍 Getting teamId from getParticipantTeamId...");
@@ -636,11 +637,13 @@ export function HuntDetails() {
                 onRetry: (attempt, error) => {
                   console.log(`❌ No teamId found yet, retrying... (attempt ${attempt}/${MAX_RETRIES})`);
                   console.error("Retry due to error:", error.message);
-                  toast.loading(`Still waiting for confirmation... (attempt ${attempt + 1}/${MAX_RETRIES})`, { id: waitToastId });
+                  toast.dismiss(); // Dismiss previous loading toast
+                  toast.loading(`Still waiting for confirmation... (attempt ${attempt + 1}/${MAX_RETRIES})`);
                 }
               });
 
-              toast.success("Confirmed on-chain. Generating invite...", { id: waitToastId });
+              toast.dismiss(); // Dismiss the loading toast
+              toast.success("Confirmed on-chain. Generating invite...");
               await generateInviteAfterTeamCreation(teamId);
               refetchTeamData();
               
@@ -945,7 +948,7 @@ export function HuntDetails() {
                       ) : (
                         <div className="w-full max-w-md">
                           {showInviteWarning && (
-                            <Alert variant="warning" className="mb-4 border-2 border-black shadow-[-2px_2px_0px_0px_rgba(0,0,0,1)]">
+                            <Alert variant="default" className="mb-4 border-2 border-black shadow-[-2px_2px_0px_0px_rgba(0,0,0,1)]">
                               <BsExclamationTriangle className="h-4 w-4" />
                               <AlertTitle className="font-bold">Important!</AlertTitle>
                               <AlertDescription className="font-medium">

--- a/frontend/src/components/HuntEnd.tsx
+++ b/frontend/src/components/HuntEnd.tsx
@@ -10,7 +10,7 @@ import { useReadContract, useActiveAccount } from "thirdweb/react";
 import { getContract } from "thirdweb";
 import { huntABI } from "../assets/hunt_abi";
 import { useNetworkState } from "../lib/utils";
-import { toast } from "sonner";
+import { toast } from "@/components/ui/toast";
 import { client } from "../lib/client";
 import { Hunt, Team } from "../types";
 import { fetchTeamCombinedScore } from "../utils/leaderboardUtils";

--- a/frontend/src/components/Hunts.tsx
+++ b/frontend/src/components/Hunts.tsx
@@ -6,7 +6,7 @@ import { useNavigate } from "react-router-dom";
 import { useActiveAccount, useReadContract } from "thirdweb/react";
 import { getContract } from "thirdweb";
 import { huntABI } from "../assets/hunt_abi.ts";
-import { toast } from "sonner";
+import { toast } from "@/components/ui/toast";
 
 import { TransactionButton } from "./TransactionButton";
 import { Button } from "./ui/button.tsx";

--- a/frontend/src/components/Leaderboard.tsx
+++ b/frontend/src/components/Leaderboard.tsx
@@ -5,7 +5,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '.
 import { FaTrophy, FaMedal } from 'react-icons/fa';
 import { FiRefreshCw } from 'react-icons/fi';
 import { cn } from '@/lib/utils';
-import { toast } from 'sonner';
+import { toast } from '@/components/ui/toast';
 import { TeamIdentifierDisplay, isSoloParticipant } from './TeamIdentifierDisplay';
 import { AddressDisplay } from './AddressDisplay';
 import { useNetworkState } from '../lib/utils';

--- a/frontend/src/components/ui/alert.tsx
+++ b/frontend/src/components/ui/alert.tsx
@@ -1,61 +1,66 @@
-import * as React from "react"
 import { cva, type VariantProps } from "class-variance-authority"
+
+import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
 const alertVariants = cva(
-  "relative w-full rounded-lg border p-4 [&>svg~*]:pl-7 [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground",
+  "relative w-full rounded-base border-2 border-border px-4 py-3 text-sm grid has-[>svg]:grid-cols-[calc(var(--spacing)*4)_1fr] grid-cols-[0_1fr] has-[>svg]:gap-x-3 gap-y-0.5 items-start [&>svg]:size-4 [&>svg]:translate-y-0.5 [&>svg]:text-current shadow-shadow",
   {
     variants: {
       variant: {
-        default: "bg-background text-foreground",
-        destructive:
-          "border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive",
-        warning:
-          "border-yellow-500/50 bg-yellow-50 text-yellow-800 dark:border-yellow-500 [&>svg]:text-yellow-500",
+        default: "bg-white text-black",
+        destructive: "bg-red-600 text-white",
       },
     },
     defaultVariants: {
       variant: "default",
     },
-  }
+  },
 )
 
-const Alert = React.forwardRef<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof alertVariants>
->(({ className, variant, ...props }, ref) => (
-  <div
-    ref={ref}
-    role="alert"
-    className={cn(alertVariants({ variant }), className)}
-    {...props}
-  />
-))
-Alert.displayName = "Alert"
+function Alert({
+  className,
+  variant,
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof alertVariants>) {
+  return (
+    <div
+      data-slot="alert"
+      role="alert"
+      className={cn(alertVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
 
-const AlertTitle = React.forwardRef<
-  HTMLParagraphElement,
-  React.HTMLAttributes<HTMLHeadingElement>
->(({ className, ...props }, ref) => (
-  <h5
-    ref={ref}
-    className={cn("mb-1 font-medium leading-none tracking-tight", className)}
-    {...props}
-  />
-))
-AlertTitle.displayName = "AlertTitle"
+function AlertTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-title"
+      className={cn(
+        "col-start-2 line-clamp-1 min-h-4 font-heading tracking-tight",
+        className,
+      )}
+      {...props}
+    />
+  )
+}
 
-const AlertDescription = React.forwardRef<
-  HTMLParagraphElement,
-  React.HTMLAttributes<HTMLParagraphElement>
->(({ className, ...props }, ref) => (
-  <div
-    ref={ref}
-    className={cn("text-sm [&_p]:leading-relaxed", className)}
-    {...props}
-  />
-))
-AlertDescription.displayName = "AlertDescription"
+function AlertDescription({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-description"
+      className={cn(
+        "col-start-2 grid justify-items-start gap-1 text-sm font-base [&_p]:leading-relaxed",
+        className,
+      )}
+      {...props}
+    />
+  )
+}
 
 export { Alert, AlertTitle, AlertDescription }

--- a/frontend/src/components/ui/sonner.tsx
+++ b/frontend/src/components/ui/sonner.tsx
@@ -9,18 +9,6 @@ const Toaster = ({ ...props }: ToasterProps) => {
   return (
     <Sonner
       theme={theme as ToasterProps["theme"]}
-      className="toaster group"
-      toastOptions={{
-        classNames: {
-          toast:
-            "group toast group-[.toaster]:bg-white group-[.toaster]:text-neutral-950 group-[.toaster]:border-neutral-200 group-[.toaster]:shadow-lg dark:group-[.toaster]:bg-neutral-950 dark:group-[.toaster]:text-neutral-50 dark:group-[.toaster]:border-neutral-800",
-          description: "group-[.toast]:text-neutral-500 dark:group-[.toast]:text-neutral-400",
-          actionButton:
-            "group-[.toast]:bg-neutral-900 group-[.toast]:text-neutral-50 dark:group-[.toast]:bg-neutral-50 dark:group-[.toast]:text-neutral-900",
-          cancelButton:
-            "group-[.toast]:bg-neutral-100 group-[.toast]:text-neutral-500 dark:group-[.toast]:bg-neutral-800 dark:group-[.toast]:text-neutral-400",
-        },
-      }}
       {...props}
     />
   )

--- a/frontend/src/components/ui/toast.tsx
+++ b/frontend/src/components/ui/toast.tsx
@@ -1,0 +1,78 @@
+import { toast as sonnerToast } from "sonner"
+import { Alert, AlertTitle, AlertDescription } from "@/components/ui/alert"
+import { CheckCircle2, XCircle, Info, AlertCircle } from "lucide-react"
+import * as React from "react"
+
+type ToastOptions = Parameters<typeof sonnerToast>[1] & {
+  description?: string
+}
+
+const createToastWithAlert = (
+  icon: React.ReactNode,
+  title: string,
+  variant: "default" | "destructive" = "default",
+  options?: ToastOptions
+) => {
+  const { description, ...toastOptions } = options || {}
+  
+  return sonnerToast.custom(
+    () => (
+      <Alert variant={variant}>
+        {icon}
+        <AlertTitle>{title}</AlertTitle>
+        {description && <AlertDescription>{description}</AlertDescription>}
+      </Alert>
+    ),
+    {
+      ...toastOptions,
+      // When updating a loading toast (has id), explicitly set a finite duration and make it dismissible
+      // Loading toasts have duration: Infinity by default, so we need to override it
+      duration: toastOptions?.id && !toastOptions?.duration ? 4000 : (toastOptions?.duration ?? 4000),
+      dismissible: true,
+    }
+  )
+}
+
+export const toast = {
+  success: (message: string, options?: ToastOptions) => {
+    return createToastWithAlert(
+      <CheckCircle2 />,
+      message,
+      "default",
+      options
+    )
+  },
+  error: (message: string, options?: ToastOptions) => {
+    return createToastWithAlert(
+      <XCircle />,
+      message,
+      "destructive",
+      options
+    )
+  },
+  info: (message: string, options?: ToastOptions) => {
+    return createToastWithAlert(
+      <Info />,
+      message,
+      "default",
+      options
+    )
+  },
+  warning: (message: string, options?: ToastOptions) => {
+    return createToastWithAlert(
+      <AlertCircle />,
+      message,
+      "default",
+      options
+    )
+  },
+  loading: (message: string, options?: ToastOptions) => {
+    // Keep loading toasts as regular sonner toasts since they're often updated by ID
+    return sonnerToast.loading(message, options)
+  },
+  // Expose other sonner methods as needed
+  custom: sonnerToast.custom,
+  promise: sonnerToast.promise,
+  dismiss: sonnerToast.dismiss,
+}
+

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -4,7 +4,7 @@ import App from './App.tsx'
 import { Providers } from './providers.tsx'
 import './index.css'
 import { HuddleClient, HuddleProvider } from "@huddle01/react";
-import { Toaster } from "sonner";
+import { Toaster } from "@/components/ui/sonner";
 
 const huddleClient = new HuddleClient({
   projectId: import.meta.env.VITE_PUBLIC_HUDDLE_PROJECT_ID!,

--- a/frontend/src/utils/progressUtils.ts
+++ b/frontend/src/utils/progressUtils.ts
@@ -1,4 +1,4 @@
-import { toast } from "sonner";
+import { toast } from "@/components/ui/toast";
 
 const BACKEND_URL = import.meta.env.VITE_PUBLIC_BACKEND_URL;
 


### PR DESCRIPTION
- Create new toast utility in components/ui/toast.tsx that wraps sonner with Alert components from shadcn
- Replace all toast imports from "sonner" to "@/components/ui/toast"
- Simplify toast update pattern in HuntDetails.tsx:
  - Remove waitToastId pattern that was causing spinner to persist
  - Use toast.dismiss() followed by new toast for cleaner transitions
- Make all toasts dismissible with 4s auto-dismiss duration

<img width="426" height="924" alt="image" src="https://github.com/user-attachments/assets/d84ccff0-3ddd-47ed-9b18-b452bb7e66d1" />


Closes #167 