### PR TITLE
feat(core): Enable Thirdweb paymaster with EIP7702

### DIFF
--- a/frontend/src/components/Create.tsx
+++ b/frontend/src/components/Create.tsx
@@ -1042,7 +1042,7 @@ export function Create() {
           )}
 
           {/* Create Hunt Button - Moved to right side */}
-          <div className="mt-8">
+          <div className="my-8">
             {canCreateHunt ? (
               <TransactionButton
                 contractAddress={contractAddress}

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -1,5 +1,5 @@
 import { Link } from "react-router-dom";
-import { User, Map } from "lucide-react";
+import { User, Map, Plus } from "lucide-react";
 
 export function Footer() {
   return (
@@ -11,6 +11,13 @@ export function Footer() {
         >
           <Map className="w-5 h-5" />
           <span className="text-xs">Hunts</span>
+        </Link>
+        <Link
+          to="/hunts/create"
+          className="flex flex-col items-center gap-0.5 text-gray-600 hover:text-green"
+        >
+          <Plus className="w-5 h-5" />
+          <span className="text-xs">Create</span>
         </Link>
         <Link 
           to="/profile"

--- a/frontend/src/components/WalletWrapper.tsx
+++ b/frontend/src/components/WalletWrapper.tsx
@@ -1,7 +1,20 @@
 import { ConnectButton, lightTheme } from "thirdweb/react";
+import { inAppWallet, createWallet } from "thirdweb/wallets";
 import { client } from "../lib/client";
 import { ENABLED_CHAINS_ARRAY } from "../lib/utils";
 import { WalletWrapperParams } from "../types";
+
+const wallets = [
+  inAppWallet({
+    executionMode: {
+      mode: "EIP7702",
+      sponsorGas: true,
+    },
+  }),
+  createWallet("io.metamask"),
+  createWallet("com.coinbase.wallet"),
+  createWallet("me.rainbow"),
+];
 
 const customTheme = lightTheme({
   colors: {
@@ -24,6 +37,7 @@ export default function WalletWrapper({
   return (
     <ConnectButton
       client={client}
+      wallets={wallets}
       chains={ENABLED_CHAINS_ARRAY}
       theme={customTheme}
       connectButton={{

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -92,7 +92,7 @@ export const getCurrentNetwork = () => {
   if (stored && ENABLED_CHAINS[stored as keyof typeof ENABLED_CHAINS]) {
     return stored;
   }
-  return ENABLED_NETWORKS[0] || "moonbeam";
+  return ENABLED_NETWORKS[0] || "base";
 };
 
 // Helper function to get contract address for current network


### PR DESCRIPTION
- this will make it easy for ppl to onboard without needing any tokens to sign up
- currently only works with base sepolia in my testing, even though moonbase alpha supports EIP7702 as per the thirdweb docs: https://thirdweb.com/moonbase-alpha . But it dosnt work. 
- Also thirdweb is not mentioned in the exported chains by thirdweb. If this is fixed then it would probably work.

Closes #182 