### PR TITLE
feat(clue): Add support to skip clues

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -18,13 +18,14 @@ import {
   verifyLocation,
   verifyImage,
 } from "./services/verification.js";
-import { attestClueSolved, attestClueAttempt, queryAttestationsForHunt, queryRetryAttemptsForClue, CLUE_STATUS } from "./services/sign-protocol.js";
+import { attestClueSolved, attestClueAttempt, queryAttestationsForHunt, queryRetryAttemptsForClue } from "./services/sign-protocol.js";
 import { calculateLeaderboardForHunt, buildAttestationTimeline } from "./services/leaderboard.js";
 import { generateImageEmbedding } from "./services/vertex-ai.js";
 
 // Import utilities
 import { withRetry } from "./utils/retry-utils.js";
 import { createCorsOptionsFromEnv, isOriginAllowed, getAllowedCorsOriginsFromEnv } from "./utils/cors.js";
+import { CLUE_STATUS } from "./utils/constants.js";
 
 // Load environment variables
 dotenv.config();

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -18,7 +18,7 @@ import {
   verifyLocation,
   verifyImage,
 } from "./services/verification.js";
-import { attestClueSolved, attestClueAttempt, queryAttestationsForHunt, queryRetryAttemptsForClue } from "./services/sign-protocol.js";
+import { attestClueSolved, attestClueAttempt, queryAttestationsForHunt, queryRetryAttemptsForClue, CLUE_STATUS } from "./services/sign-protocol.js";
 import { calculateLeaderboardForHunt, buildAttestationTimeline } from "./services/leaderboard.js";
 import { generateImageEmbedding } from "./services/vertex-ai.js";
 
@@ -745,7 +745,19 @@ app.post("/attestations/attempts", async (req, res) => {
 // Attest clue solve endpoint
 app.post("/attestations/clues", async (req, res) => {
   try {
-    const { teamIdentifier, teamName, huntId, clueIndex, teamLeaderAddress, solverAddress, timeTaken, attemptCount, chainId, contractAddress } = req.body;
+    const {
+      teamIdentifier,
+      teamName,
+      huntId,
+      clueIndex,
+      teamLeaderAddress,
+      solverAddress,
+      timeTaken,
+      attemptCount,
+      chainId,
+      contractAddress,
+      status = CLUE_STATUS.SOLVED,
+    } = req.body;
 
     // Validate required fields
     if (huntId === undefined || clueIndex === undefined || !teamLeaderAddress || !teamIdentifier || !solverAddress || timeTaken === undefined || attemptCount === undefined || !chainId || !contractAddress) {
@@ -767,6 +779,7 @@ app.post("/attestations/clues", async (req, res) => {
       attemptCount,
       chainId,
       contractAddress,
+      status,
     });
 
     const attestationInfo = await attestClueSolved(
@@ -779,7 +792,8 @@ app.post("/attestations/clues", async (req, res) => {
       timeTaken,
       attemptCount,
       chainId,
-      contractAddress
+      contractAddress,
+      status
     );
 
     res.json({

--- a/backend/src/services/leaderboard.js
+++ b/backend/src/services/leaderboard.js
@@ -15,6 +15,8 @@
  * @param {Array} attestations - Array of attestation objects with data field
  * @returns {Array} Ranked leaderboard array
  */
+import { CLUE_STATUS } from "./sign-protocol.js";
+
 export function calculateLeaderboard(attestations) {
   if (!attestations || attestations.length === 0) {
     return [];
@@ -25,6 +27,9 @@ export function calculateLeaderboard(attestations) {
   
   for (const attestation of attestations) {
     const data = JSON.parse(attestation.data);
+    if (data.status === CLUE_STATUS.SKIPPED) {
+      continue;
+    }
     const teamIdentifier = data.teamIdentifier;
     
     if (!teamData.has(teamIdentifier)) {
@@ -167,8 +172,18 @@ export function buildAttestationTimeline({
       }
     }
 
-    const retryAttestations = retryAttestationsByClue?.get(clueIndex) ?? [];
+    const solveAttestation = list.find(
+      (a) => parseInt(a.parsedData.clueIndex) === clueIndex
+    );
     const entries = [];
+    let solveAttemptCount = null;
+
+    if (solveAttestation) {
+      const data = solveAttestation.parsedData;
+      solveAttemptCount = parseInt(data.attemptCount);
+    }
+
+    const retryAttestations = retryAttestationsByClue?.get(clueIndex) ?? [];
 
     if (retryAttestations.length > 0) {
       const sortedRetries = retryAttestations
@@ -179,26 +194,26 @@ export function buildAttestationTimeline({
           const timeTaken = clueStartTimestamp != null
             ? Math.max(0, retryTimestamp - clueStartTimestamp)
             : 0;
+          const attemptCount = parseInt(data.attemptCount);
           return {
             type: "retry",
-            attemptCount: parseInt(data.attemptCount),
+            attemptCount,
             attestationId: a.attestationId,
             timestamp: retryTimestamp,
             timeTaken,
             clueIndex,
           };
         })
+        // Filter out the retry that corresponds to the final solve attempt
+        .filter((entry) => solveAttemptCount == null || entry.attemptCount !== solveAttemptCount)
         .sort((a, b) => a.timestamp - b.timestamp);
       entries.push(...sortedRetries);
     }
 
-    const solveAttestation = list.find(
-      (a) => parseInt(a.parsedData.clueIndex) === clueIndex
-    );
     if (solveAttestation) {
       const data = solveAttestation.parsedData;
       entries.push({
-        type: "solve",
+        type: data.status === CLUE_STATUS.SKIPPED ? "skip" : "solve",
         attemptCount: parseInt(data.attemptCount),
         attestationId: solveAttestation.attestationId,
         timestamp: Math.floor(Number(solveAttestation.attestTimestamp) / 1000),

--- a/backend/src/services/leaderboard.js
+++ b/backend/src/services/leaderboard.js
@@ -15,7 +15,7 @@
  * @param {Array} attestations - Array of attestation objects with data field
  * @returns {Array} Ranked leaderboard array
  */
-import { CLUE_STATUS } from "./sign-protocol.js";
+import { CLUE_STATUS } from "../utils/constants.js";
 
 export function calculateLeaderboard(attestations) {
   if (!attestations || attestations.length === 0) {

--- a/backend/src/services/sign-protocol.js
+++ b/backend/src/services/sign-protocol.js
@@ -9,11 +9,7 @@ import { privateKeyToAccount } from "viem/accounts";
 import dotenv from "dotenv";
 import { fileURLToPath } from "url";
 import { dirname, resolve } from "path";
-
-export const CLUE_STATUS = {
-  SOLVED: "solved",
-  SKIPPED: "skipped",
-};
+import { CLUE_STATUS } from "../utils/constants.js";
 
 // Get the directory of the current module
 const __filename = fileURLToPath(import.meta.url);

--- a/backend/src/services/sign-protocol.js
+++ b/backend/src/services/sign-protocol.js
@@ -10,6 +10,11 @@ import dotenv from "dotenv";
 import { fileURLToPath } from "url";
 import { dirname, resolve } from "path";
 
+export const CLUE_STATUS = {
+  SOLVED: "solved",
+  SKIPPED: "skipped",
+};
+
 // Get the directory of the current module
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -47,11 +52,6 @@ const client = new SignProtocolClient(SpMode.OffChain, {
 
 // Initialize Index Service for querying attestations
 const indexService = new IndexService('mainnet');
-
-export const CLUE_STATUS = {
-  SOLVED: "solved",
-  SKIPPED: "skipped",
-};
 
 // Schema definition for clue solving attestations (when a clue is successfully solved)
 const CLUE_SCHEMA = {

--- a/backend/src/services/sign-protocol.js
+++ b/backend/src/services/sign-protocol.js
@@ -48,6 +48,11 @@ const client = new SignProtocolClient(SpMode.OffChain, {
 // Initialize Index Service for querying attestations
 const indexService = new IndexService('mainnet');
 
+export const CLUE_STATUS = {
+  SOLVED: "solved",
+  SKIPPED: "skipped",
+};
+
 // Schema definition for clue solving attestations (when a clue is successfully solved)
 const CLUE_SCHEMA = {
   name: "Khoj Clue Solve",
@@ -62,6 +67,7 @@ const CLUE_SCHEMA = {
     { name: "timeTaken", type: "uint256" }, // Time taken to solve in seconds
     { name: "attemptCount", type: "uint256" },
     { name: "chainId", type: "uint256" },
+    { name: "status", type: "string" },
   ],
 };
 
@@ -222,7 +228,8 @@ export async function attestClueSolved(
   timeTaken,
   attemptCount,
   chainId,
-  contractAddress
+  contractAddress,
+  status = CLUE_STATUS.SOLVED
 ) {
   try {
     if (!schemaId) {
@@ -241,6 +248,7 @@ export async function attestClueSolved(
       timeTaken,
       attemptCount,
       chainId,
+      status,
       indexingValue,
     });
 
@@ -254,6 +262,7 @@ export async function attestClueSolved(
       timeTaken: timeTaken.toString(),
       attemptCount: attemptCount.toString(),
       chainId: chainId,
+      status: status,
     };
 
     const attestationInfo = await client.createAttestation({

--- a/backend/src/utils/constants.js
+++ b/backend/src/utils/constants.js
@@ -1,0 +1,4 @@
+export const CLUE_STATUS = {
+    SOLVED: "solved",
+    SKIPPED: "skipped",
+};

--- a/backend/tests/leaderboard.test.js
+++ b/backend/tests/leaderboard.test.js
@@ -5,7 +5,7 @@
  */
 
 import { calculateLeaderboard, buildAttestationTimeline } from '../src/services/leaderboard.js';
-import { CLUE_STATUS } from '../src/services/sign-protocol.js';
+import { CLUE_STATUS } from '../src/utils/constants.js';
 
 // Mock attestation data for testing leaderboard logic
 const mockAttestations = [

--- a/backend/tests/leaderboard.test.js
+++ b/backend/tests/leaderboard.test.js
@@ -5,6 +5,7 @@
  */
 
 import { calculateLeaderboard, buildAttestationTimeline } from '../src/services/leaderboard.js';
+import { CLUE_STATUS } from '../src/services/sign-protocol.js';
 
 // Mock attestation data for testing leaderboard logic
 const mockAttestations = [
@@ -301,6 +302,146 @@ describe('Leaderboard Logic', () => {
       expect(avgAttempts).toBe(3.4);
     });
   });
+
+  describe('Leaderboard with skipped clues', () => {
+    const mockAttestationsWithSkips = [
+      // Team A: solves clue 1 and 3, skips clue 2
+      {
+        data: JSON.stringify({
+          teamIdentifier: "A",
+          huntId: "0",
+          clueIndex: "1",
+          teamLeaderAddress: "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          solverAddress: "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          timeTaken: "300",
+          attemptCount: "1",
+          status: CLUE_STATUS.SOLVED,
+        }),
+      },
+      {
+        data: JSON.stringify({
+          teamIdentifier: "A",
+          huntId: "0",
+          clueIndex: "2",
+          teamLeaderAddress: "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          solverAddress: "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          timeTaken: "120",
+          attemptCount: "0",
+          status: CLUE_STATUS.SKIPPED,
+        }),
+      },
+      {
+        data: JSON.stringify({
+          teamIdentifier: "A",
+          huntId: "0",
+          clueIndex: "3",
+          teamLeaderAddress: "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          solverAddress: "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          timeTaken: "400",
+          attemptCount: "2",
+          status: CLUE_STATUS.SOLVED,
+        }),
+      },
+
+      // Team B: solves all 3, no skips
+      {
+        data: JSON.stringify({
+          teamIdentifier: "B",
+          huntId: "0",
+          clueIndex: "1",
+          teamLeaderAddress: "0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+          solverAddress: "0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+          timeTaken: "600",
+          attemptCount: "3",
+          status: CLUE_STATUS.SOLVED,
+        }),
+      },
+      {
+        data: JSON.stringify({
+          teamIdentifier: "B",
+          huntId: "0",
+          clueIndex: "2",
+          teamLeaderAddress: "0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+          solverAddress: "0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+          timeTaken: "500",
+          attemptCount: "2",
+          status: CLUE_STATUS.SOLVED,
+        }),
+      },
+      {
+        data: JSON.stringify({
+          teamIdentifier: "B",
+          huntId: "0",
+          clueIndex: "3",
+          teamLeaderAddress: "0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+          solverAddress: "0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+          timeTaken: "400",
+          attemptCount: "1",
+          status: CLUE_STATUS.SOLVED,
+        }),
+      },
+
+      // Team C: no status field (backward compat -- treated as solved)
+      {
+        data: JSON.stringify({
+          teamIdentifier: "C",
+          huntId: "0",
+          clueIndex: "1",
+          teamLeaderAddress: "0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC",
+          solverAddress: "0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC",
+          timeTaken: "200",
+          attemptCount: "1",
+        }),
+      },
+
+      // Team D: all skipped (should not appear)
+      {
+        data: JSON.stringify({
+          teamIdentifier: "D",
+          huntId: "0",
+          clueIndex: "1",
+          teamLeaderAddress: "0xDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD",
+          solverAddress: "0xDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD",
+          timeTaken: "60",
+          attemptCount: "0",
+          status: CLUE_STATUS.SKIPPED,
+        }),
+      },
+    ];
+
+    test('skipped clues are excluded from scoring', () => {
+      const lb = calculateLeaderboard(mockAttestationsWithSkips);
+      const teamA = lb.find((t) => t.teamIdentifier === "A");
+      expect(teamA).toBeDefined();
+      expect(teamA.cluesCompleted).toBe(2);
+      expect(teamA.totalTime).toBe(700); // 300 + 400
+      expect(teamA.totalAttempts).toBe(3); // 1 + 2
+    });
+
+    test('ranking uses solved clue count, not skipped', () => {
+      const lb = calculateLeaderboard(mockAttestationsWithSkips);
+      const teamB = lb.find((t) => t.teamIdentifier === "B");
+      const teamA = lb.find((t) => t.teamIdentifier === "A");
+      expect(teamB).toBeDefined();
+      expect(teamA).toBeDefined();
+      expect(teamB.cluesCompleted).toBe(3);
+      expect(teamA.cluesCompleted).toBe(2);
+      expect(teamB.rank).toBeLessThan(teamA.rank);
+    });
+
+    test('attestations without status are treated as solved (backward compat)', () => {
+      const lb = calculateLeaderboard(mockAttestationsWithSkips);
+      const teamC = lb.find((t) => t.teamIdentifier === "C");
+      expect(teamC).toBeDefined();
+      expect(teamC.cluesCompleted).toBe(1);
+    });
+
+    test('team with only skipped clues does not appear on leaderboard', () => {
+      const lb = calculateLeaderboard(mockAttestationsWithSkips);
+      const teamD = lb.find((t) => t.teamIdentifier === "D");
+      expect(teamD).toBeUndefined();
+    });
+  });
 });
 
 describe('Attestation Timeline', () => {
@@ -515,6 +656,185 @@ describe('Attestation Timeline', () => {
         expect(clue.attempts.length).toBe(1);
         expect(clue.attempts[0].type).toBe('solve');
       });
+    });
+  });
+
+  describe('Timeline with skipped clues', () => {
+    test('skipped solve attestation produces type \"skip\"', () => {
+      const skippedSolveAttestations = [
+        {
+          data: JSON.stringify({
+            teamIdentifier: teamId,
+            clueIndex: '1',
+            timeTaken: '600',
+            attemptCount: '2',
+            status: CLUE_STATUS.SOLVED,
+          }),
+          attestTimestamp: 1_600_000,
+          attestationId: 'solve-clue1',
+        },
+        {
+          data: JSON.stringify({
+            teamIdentifier: teamId,
+            clueIndex: '2',
+            timeTaken: '120',
+            attemptCount: '0',
+            status: CLUE_STATUS.SKIPPED,
+          }),
+          attestTimestamp: 1_720_000,
+          attestationId: 'skip-clue2',
+        },
+      ];
+
+      const teamSolveAttestationsWithSkip = skippedSolveAttestations.map((a) => ({
+        ...a,
+        parsedData: JSON.parse(a.data),
+      }));
+
+      const retryMap = new Map([
+        [1, []],
+        [2, []],
+      ]);
+
+      const result = buildAttestationTimeline({
+        teamSolveAttestations: teamSolveAttestationsWithSkip,
+        solvedClueIndices: [1, 2],
+        retryAttestationsByClue: retryMap,
+        huntStartAttestations,
+        teamIdentifier: teamId,
+        huntId,
+      });
+
+      const clue2 = result.clues.find((c) => c.clueIndex === 2);
+      expect(clue2).toBeDefined();
+      expect(clue2.attempts.length).toBe(1);
+      expect(clue2.attempts[0].type).toBe('skip');
+      expect(clue2.attempts[0].timeTaken).toBe(120);
+      expect(clue2.attempts[0].attestationId).toBe('skip-clue2');
+    });
+
+    test('skip with retries keeps earlier retries and ends with skip, without duplicate final retry', () => {
+      const skippedSolveAttestations = [
+        {
+          data: JSON.stringify({
+            teamIdentifier: teamId,
+            clueIndex: '1',
+            timeTaken: '600',
+            attemptCount: '2',
+            status: CLUE_STATUS.SKIPPED,
+          }),
+          attestTimestamp: 1_600_000,
+          attestationId: 'skip-clue1',
+        },
+      ];
+
+      const teamSolveAttestationsWithSkip = skippedSolveAttestations.map((a) => ({
+        ...a,
+        parsedData: JSON.parse(a.data),
+      }));
+
+      const retryClue1WithTwo = [
+        {
+          data: JSON.stringify({ attemptCount: '1' }),
+          attestTimestamp: 1_300_000,
+          attestationId: 'retry1-clue1',
+        },
+        {
+          data: JSON.stringify({ attemptCount: '2' }),
+          attestTimestamp: 1_400_000,
+          attestationId: 'retry2-clue1',
+        },
+      ];
+
+      const retryMap = new Map([[1, retryClue1WithTwo]]);
+
+      const result = buildAttestationTimeline({
+        teamSolveAttestations: teamSolveAttestationsWithSkip,
+        solvedClueIndices: [1],
+        retryAttestationsByClue: retryMap,
+        huntStartAttestations,
+        teamIdentifier: teamId,
+        huntId,
+      });
+
+      const clue1 = result.clues.find((c) => c.clueIndex === 1);
+      expect(clue1).toBeDefined();
+      // Retry with attemptCount=2 is filtered out; we keep attempt 1 + final skip
+      expect(clue1.attempts.length).toBe(2);
+      expect(clue1.attempts[0].type).toBe('retry');
+      expect(clue1.attempts[0].attemptCount).toBe(1);
+      expect(clue1.attempts[1].type).toBe('skip');
+      expect(clue1.attempts[1].attemptCount).toBe(2);
+    });
+  });
+
+  describe('Timeline with solve + matching retry attemptCount', () => {
+    test('omits retry entry whose attemptCount equals solve attemptCount', () => {
+      const localHuntId = 2;
+      const localTeamId = 'team-beta';
+
+      const localHuntStartAttestations = [
+        {
+          data: JSON.stringify({ attemptCount: '0' }),
+          attestTimestamp: 2_000_000,
+          attestationId: 'start-team-beta',
+        },
+      ];
+
+      const localSolveAttestations = [
+        {
+          data: JSON.stringify({
+            teamIdentifier: localTeamId,
+            clueIndex: '1',
+            timeTaken: '120',
+            attemptCount: '2',
+            status: CLUE_STATUS.SOLVED,
+          }),
+          attestTimestamp: 2_120_000,
+          attestationId: 'solve-team-beta-clue1',
+        },
+      ];
+
+      const localTeamSolveAttestations = localSolveAttestations.map((a) => ({
+        ...a,
+        parsedData: JSON.parse(a.data),
+      }));
+
+      const localRetryAttestationsByClue = new Map([
+        [
+          1,
+          [
+            {
+              data: JSON.stringify({ attemptCount: '1' }),
+              attestTimestamp: 2_060_000,
+              attestationId: 'retry1-team-beta-clue1',
+            },
+            {
+              data: JSON.stringify({ attemptCount: '2' }),
+              attestTimestamp: 2_100_000,
+              attestationId: 'retry2-team-beta-clue1',
+            },
+          ],
+        ],
+      ]);
+
+      const result = buildAttestationTimeline({
+        teamSolveAttestations: localTeamSolveAttestations,
+        solvedClueIndices: [1],
+        retryAttestationsByClue: localRetryAttestationsByClue,
+        huntStartAttestations: localHuntStartAttestations,
+        teamIdentifier: localTeamId,
+        huntId: localHuntId,
+      });
+
+      const clue1 = result.clues.find((c) => c.clueIndex === 1);
+      expect(clue1).toBeDefined();
+      // Only one retry (attempt 1) plus the solve
+      expect(clue1.attempts.length).toBe(2);
+      expect(clue1.attempts[0].type).toBe('retry');
+      expect(clue1.attempts[0].attemptCount).toBe(1);
+      expect(clue1.attempts[1].type).toBe('solve');
+      expect(clue1.attempts[1].attemptCount).toBe(2);
     });
   });
 });

--- a/backend/tests/sign-protocol.test.js
+++ b/backend/tests/sign-protocol.test.js
@@ -4,7 +4,13 @@
  * Note: Schema must be created first using create-schema.js
  */
 
-import { attestClueSolved, queryAttestationsForHunt, getSchemaId } from '../src/services/sign-protocol.js';
+import {
+  attestClueSolved,
+  queryAttestationsForHunt,
+  getSchemaId,
+  createClueSchema,
+  setSchemaId,
+} from '../src/services/sign-protocol.js';
 import dotenv from 'dotenv';
 
 dotenv.config();
@@ -16,6 +22,7 @@ const TEST_CONTRACT_SUFFIX = TEST_CONTRACT_ADDRESS.slice(-3);
 describe('Sign Protocol Integration', () => {
   let createdAttestations = [];
   let attestationData = [];
+  let ensuredSchema = false;
 
   beforeAll(() => {
     // Check if schema ID exists
@@ -59,7 +66,24 @@ describe('Sign Protocol Integration', () => {
   });
 
   describe('Attestation Creation', () => {
+    const ensureSchemaHasStatus = async () => {
+      if (ensuredSchema) return;
+      try {
+        // If SIGN_SCHEMA_ID already points at a schema with status, this will succeed without needing to create anything.
+        // Otherwise, create a new schema with the updated CLUE_SCHEMA (incl. status) and use it for this test run.
+        const schemaInfo = await createClueSchema();
+        if (schemaInfo?.schemaId) {
+          setSchemaId(schemaInfo.schemaId);
+        }
+      } catch (_e) {
+        // If schema creation fails, fall back to existing SIGN_SCHEMA_ID and let the test fail with a clear error.
+      } finally {
+        ensuredSchema = true;
+      }
+    };
+
     test('should create attestation for team 1', async () => {
+      await ensureSchemaHasStatus();
       const testData = attestationData[0];
 
       const result = await attestClueSolved(
@@ -82,6 +106,7 @@ describe('Sign Protocol Integration', () => {
     });
 
     test('should create attestation for team 2', async () => {
+      await ensureSchemaHasStatus();
       const testData = attestationData[1];
 
       const result = await attestClueSolved(
@@ -105,6 +130,7 @@ describe('Sign Protocol Integration', () => {
     });
 
     test('should create attestation for solo user', async () => {
+      await ensureSchemaHasStatus();
       const testData = attestationData[2];
 
       const result = await attestClueSolved(
@@ -174,7 +200,8 @@ describe('Sign Protocol Integration', () => {
         expect(attestationResultBody.timeTaken).toBeDefined();
         // Attestations are created with solverAddress as recipient
         if (attestationResult.recipients) {
-          expect(attestationResult.recipients).toEqual([attestationDatum.solverAddress]);
+          const recipients = attestationResult.recipients.map((a) => a.toLowerCase());
+          expect(recipients).toEqual([attestationDatum.solverAddress.toLowerCase()]);
         }
       }
     });
@@ -183,7 +210,9 @@ describe('Sign Protocol Integration', () => {
   describe('Schema Management', () => {
     test('should get schema ID', () => {
       const schemaId = getSchemaId();
-      expect(schemaId).toBe(process.env.SIGN_SCHEMA_ID);
+      expect(schemaId).toBeDefined();
+      expect(typeof schemaId).toBe('string');
+      expect(schemaId.length).toBeGreaterThan(0);
     });
   });
 });

--- a/frontend/src/components/AttestationTimeline.tsx
+++ b/frontend/src/components/AttestationTimeline.tsx
@@ -1,4 +1,4 @@
-import { Check, Clock, ExternalLink, X } from 'lucide-react';
+import { Check, Clock, ExternalLink, SkipForward, X } from 'lucide-react';
 import { LeaderboardAttestationsSkeleton } from './LeaderboardSkeleton';
 import { formatTimeTaken } from '@/utils/leaderboardUtils';
 import type { AttestationEntry, TeamAttestationsResponse } from '@/types/ui';
@@ -41,6 +41,8 @@ export function AttestationTimeline({ teamAttestations, isLoading }: Attestation
                 <span className="text-foreground/80 w-24">Attempt #{i + 1}</span>
                 {entry.type === 'retry' ? (
                   <X className="w-4 h-4 text-red-600 shrink-0" />
+                ) : entry.type === 'skip' ? (
+                  <SkipForward className="w-4 h-4 text-amber-600 shrink-0" />
                 ) : (
                   <Check className="w-4 h-4 text-green-600 shrink-0" />
                 )}

--- a/frontend/src/components/Clue.tsx
+++ b/frontend/src/components/Clue.tsx
@@ -4,7 +4,14 @@ import { Card, CardContent, CardHeader, CardTitle, CardFooter } from './ui/card'
 import { useState, useEffect, useRef } from 'react';
 import ReactMarkdown from 'react-markdown';
 import { cn } from '@/lib/utils';
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from './ui/dialog';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from './ui/dialog';
 import {
   BsArrowLeft,
   BsGeoAlt,
@@ -14,13 +21,9 @@ import {
   BsBarChartFill,
   BsArrowClockwise,
   BsInfoCircle,
+  BsSkipForward,
 } from 'react-icons/bs';
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from '@/components/ui/tooltip';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { HuddleRoom } from './HuddleRoom';
 import { Leaderboard } from './Leaderboard';
 import { useReadContract, useActiveAccount } from 'thirdweb/react';
@@ -29,12 +32,21 @@ import { huntABI } from '../assets/hunt_abi';
 import { useNetworkState } from '../lib/utils';
 import { toast } from '@/components/ui/toast';
 import { client } from '../lib/client';
-import { Hunt, Team, HUNT_TYPE, enumToHuntType, HuntType } from '../types';
+import {
+  CLUE_STATUS,
+  type ClueStatus,
+  Hunt,
+  Team,
+  HUNT_TYPE,
+  enumToHuntType,
+  HuntType,
+} from '../types';
 import {
   syncProgressAndNavigate,
   getTeamIdentifier,
   validateClueAccess,
   fetchProgress,
+  calculateTimeTaken,
   isClueSolved,
 } from '../utils/progressUtils';
 import {
@@ -72,6 +84,8 @@ export function Clue() {
   const [isSyncing, setIsSyncing] = useState(false);
   const [isRedirecting, setIsRedirecting] = useState(false);
   const [isCameraOpen, setIsCameraOpen] = useState(false);
+  const [isSkipDialogOpen, setIsSkipDialogOpen] = useState(false);
+  const [isSkipping, setIsSkipping] = useState(false);
   const [stream, setStream] = useState<MediaStream | null>(null);
   const [isAttemptsTooltipOpen, setIsAttemptsTooltipOpen] = useState(false);
   const videoRef = useRef<HTMLVideoElement>(null);
@@ -245,7 +259,7 @@ export function Clue() {
     }
 
     try {
-      const displayName = (teamData?.name && teamData.name.length > 0) ? teamData.name : userWallet;
+      const displayName = teamData?.name && teamData.name.length > 0 ? teamData.name : userWallet;
       const attestationData = {
         teamIdentifier,
         teamName: displayName,
@@ -278,7 +292,11 @@ export function Clue() {
   };
 
   // Create clue solve attestation
-  const createAttestation = async (timeTaken: number, totalAttempts: number) => {
+  const createAttestation = async (
+    timeTaken: number,
+    totalAttempts: number,
+    status: ClueStatus = CLUE_STATUS.SOLVED
+  ) => {
     if (
       !isDefined(userWallet) ||
       !hasRequiredClueParams({ huntId, clueId, chainId, contractAddress })
@@ -287,7 +305,7 @@ export function Clue() {
     }
 
     try {
-      const displayName = (teamData?.name && teamData.name.length > 0) ? teamData.name : userWallet;
+      const displayName = teamData?.name && teamData.name.length > 0 ? teamData.name : userWallet;
       const attestationData = {
         teamIdentifier: teamData?.teamId?.toString() || userWallet.toString(), // team id for teams, user wallet for solo users
         teamName: displayName,
@@ -297,6 +315,7 @@ export function Clue() {
         solverAddress: userWallet,
         timeTaken,
         attemptCount: totalAttempts,
+        status,
         chainId: chainId,
         contractAddress: contractAddress,
       };
@@ -314,12 +333,80 @@ export function Clue() {
       }
 
       await response.json();
-      toast.success('Clue solve recorded!');
     } catch (error) {
       console.error('Failed to create attestation:', (error as Error)?.message);
       toast.error('Failed to record clue solve');
     }
   };
+
+  const handleSkipClue = async () => {
+    if (
+      !hasRequiredClueAndTeamParams({ huntId, clueId, chainId, contractAddress, teamIdentifier })
+    ) {
+      toast.error('Missing required parameters to skip clue');
+      return;
+    }
+
+    try {
+      setIsSkipping(true);
+      setIsSkipDialogOpen(false);
+
+      // Determine current attempt count (may be 0 if user skips immediately)
+      const retryData = await fetchRetryAttempts(false);
+      const attemptCount = retryData?.attemptCount ? Number(retryData.attemptCount) : 0;
+
+      const timeTaken = await calculateTimeTaken({
+        huntId: parseInt(huntId ?? '0', 10),
+        teamIdentifier,
+        currentClue,
+        totalClues,
+        chainId,
+        contractAddress,
+      });
+
+      await createAttestation(timeTaken, attemptCount, CLUE_STATUS.SKIPPED);
+
+      const nextClueId = currentClue + 1;
+      if (currentClueData && nextClueId <= currentClueData.length) {
+        navigate(`/hunt/${huntId}/clue/${nextClueId}`);
+      } else {
+        navigate(`/hunt/${huntId}/end`);
+      }
+      toast.success(`Clue ${currentClue} skipped!`);
+    } catch (error) {
+      console.error('Failed to skip clue:', (error as Error)?.message);
+      toast.error('Failed to skip clue');
+    } finally {
+      setIsSkipping(false);
+    }
+  };
+
+  const skipDialog = (
+    <Dialog open={isSkipDialogOpen} onOpenChange={setIsSkipDialogOpen}>
+      <DialogContent className="max-w-xl w-[95vw] sm:w-[85vw]">
+        <DialogHeader>
+          <DialogTitle>Skip this clue?</DialogTitle>
+          <DialogDescription>
+            Once you skip, you cannot return to this clue. This clue will not count towards your
+            score.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => setIsSkipDialogOpen(false)}
+            disabled={isSkipping}
+          >
+            Cancel
+          </Button>
+          <Button type="button" variant="default" onClick={handleSkipClue} disabled={isSkipping}>
+            {isSkipping ? 'Skipping...' : 'Skip Clue'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
 
   // Sync progress with team
   const handleSyncProgress = async () => {
@@ -415,8 +502,8 @@ export function Clue() {
           const clueIndex = parseInt(clueId || '0');
 
           if (isClueSolved(progressData, clueIndex)) {
-            console.info('Clue already solved by team, skipping verification');
-            toast.info('This clue has already been solved by your team!');
+            console.info('Clue already completed by team, skipping verification');
+            toast.info('This clue has already been completed by your team!');
             setVerificationState('success');
             setShowSuccessMessage(true);
             haptics.success();
@@ -528,47 +615,18 @@ export function Clue() {
       const isCorrect = data.isClose === true || data.isClose === 'true';
 
       if (isCorrect) {
-        // Calculate time taken in seconds
-        const currentTimestamp = Math.floor(Date.now() / 1000);
-        let startTimestamp = currentTimestamp; // Default fallback
-
-        // Determine the correct start timestamp based on clue number
-        // For both first attempts and retries, we measure from when the clue became available
-        if (currentClue === 1) {
-          // For first clue, use hunt start timestamp from retry-attempts with clueIndex: 0
-          try {
-            const huntStartResponse = await fetch(
-              `${BACKEND_URL}/hunts/${huntId}/clues/0/teams/${teamIdentifier}/attempts?chainId=${chainId}&contractAddress=${contractAddress}`
-            );
-            if (huntStartResponse.ok) {
-              const huntStartData = await huntStartResponse.json();
-              if (huntStartData.firstAttemptTimestamp) {
-                startTimestamp = huntStartData.firstAttemptTimestamp;
-              }
-            }
-          } catch (error) {
-            console.error('Error fetching hunt start timestamp:', (error as Error)?.message);
-          }
-        } else {
-          // For other clues, use previous clue solve timestamp from progress endpoint
-          try {
-            const progressResponse = await fetch(
-              `${BACKEND_URL}/hunts/${huntId}/teams/${teamIdentifier}/progress?totalClues=${totalClues}&chainId=${chainId}&contractAddress=${contractAddress}`
-            );
-            if (progressResponse.ok) {
-              const progressData = await progressResponse.json();
-              const prevClueIndex = currentClue - 1;
-              if (progressData.solvedClues && progressData.solvedClues[prevClueIndex]) {
-                startTimestamp = progressData.solvedClues[prevClueIndex].solveTimestamp;
-              }
-            }
-          } catch (error) {
-            console.error('Error fetching previous clue solve timestamp:', (error as Error)?.message);
-          }
-        }
-
-        const timeTaken = currentTimestamp - startTimestamp;
-        console.info('Clue solved', { timeTakenSeconds: timeTaken, attempts: currentAttemptNumber });
+        const timeTaken = await calculateTimeTaken({
+          huntId: parseInt(huntId ?? '0', 10),
+          teamIdentifier,
+          currentClue,
+          totalClues,
+          chainId,
+          contractAddress,
+        });
+        console.info('Clue solved', {
+          timeTakenSeconds: timeTaken,
+          attempts: currentAttemptNumber,
+        });
 
         // Create attestation when clue is solved with timeTaken and total attempts
         await createAttestation(timeTaken, currentAttemptNumber);
@@ -592,7 +650,7 @@ export function Clue() {
         }, 500);
       } else {
         setVerificationState('error');
-        // By incrementing resultKey on each result, the button is recreated each time, 
+        // By incrementing resultKey on each result, the button is recreated each time,
         // so the wiggle animation runs again for every success or error.
         setResultKey((k) => k + 1);
         setAttempts((prev) => prev - 1);
@@ -702,20 +760,33 @@ export function Clue() {
               </div>
               <CardTitle className="text-3xl mb-4">No More Attempts</CardTitle>
               <p className="text-foreground/70 mb-8">
-                You've used all your attempts for this clue. Try another hunt or come back later.
+                You've used all your attempts for this clue. You can choose to skip this clue and continue with the next one.
+                This clue will not count towards your score.
               </p>
-              <Button
-                onClick={() => navigate('/hunts')}
-                variant="default"
-                size="lg"
-                className="px-8"
-              >
-                <BsArrowLeft className="mr-2" />
-                Return to Hunts
-              </Button>
+              <div className="flex flex-col sm:flex-row gap-3 justify-center">
+                <Button
+                  onClick={() => setIsSkipDialogOpen(true)}
+                  variant="default"
+                  size="lg"
+                  className="px-8"
+                  disabled={isSkipping}
+                >
+                  <BsSkipForward className="mr-2" />
+                </Button>
+                <Button
+                  onClick={() => navigate('/hunts')}
+                  variant="outline"
+                  size="lg"
+                  className="px-8"
+                >
+                  <BsArrowLeft className="mr-2" />
+                  Return to Hunts
+                </Button>
+              </div>
             </CardContent>
           </Card>
         </div>
+        {skipDialog}
       </div>
     );
   }
@@ -725,32 +796,46 @@ export function Clue() {
       <div className="max-w-4xl mx-auto">
         <Card className="mb-8 min-h-[calc(100vh-180px)] flex flex-col bg-white">
           <CardHeader className="bg-main text-main-foreground p-6 -my-6">
-            <div className="flex items-center justify-between">
-              <CardTitle className="text-xl flex-1 wrap-break-word">{huntData?.name}</CardTitle>
-              <div className="flex items-center space-x-4">
-                <div className="text-2xl shrink-0">
-                  # {currentClue}/{currentClueData?.length}
+            <div className="flex flex-row justify-between">
+              <div className="flex flex-col">
+                <CardTitle className="text-xl wrap-break-word">{huntData?.name}</CardTitle>
+                <div className="flex items-center justify-between">
+                  <div className="text-xl">
+                    # {currentClue}/{currentClueData?.length}
+                  </div>
                 </div>
-                <div className="flex items-center space-x-2">
-                  <Button
-                    onClick={handleSyncProgress}
-                    disabled={isSyncing}
-                    variant="neutral"
-                    size="sm"
-                    className="p-2"
-                    title="Sync with team progress"
-                  >
-                    <BsArrowClockwise className={`w-4 h-4 ${isSyncing ? 'animate-spin' : ''}`} />
-                  </Button>
-                  <Button
-                    onClick={() => setIsLeaderboardOpen(true)}
-                    variant="neutral"
-                    size="sm"
-                    className="p-2"
-                  >
-                    <BsBarChartFill className="w-4 h-4" />
-                  </Button>
-                </div>
+              </div>
+              <div className="flex items-center space-x-2 mb-1">
+                <Button
+                  type="button"
+                  onClick={() => setIsSkipDialogOpen(true)}
+                  variant="neutral"
+                  size="sm"
+                  className="p-2"
+                  title="Skip this clue"
+                  disabled={verificationState === 'verifying' || isRedirecting || isSyncing || isSkipping}
+                >
+                  <BsSkipForward className="w-4 h-4" />
+                </Button>
+                <Button
+                  onClick={handleSyncProgress}
+                  variant="neutral"
+                  size="sm"
+                  className="p-2"
+                  title="Sync with team progress"
+                  disabled={verificationState === 'verifying' || isRedirecting || isSyncing || isSkipping}
+                >
+                  <BsArrowClockwise className={`w-4 h-4 ${isSyncing ? 'animate-spin' : ''}`} />
+                </Button>
+                <Button
+                  onClick={() => setIsLeaderboardOpen(true)}
+                  variant="neutral"
+                  size="sm"
+                  className="p-2"
+                  disabled={verificationState === 'verifying' || isRedirecting || isSyncing || isSkipping }
+                >
+                  <BsBarChartFill className="w-4 h-4" />
+                </Button>
               </div>
             </div>
           </CardHeader>
@@ -800,8 +885,16 @@ export function Clue() {
                           <BsInfoCircle className="w-3.5 h-3.5" />
                         </button>
                       </TooltipTrigger>
-                      <TooltipContent side="top" sideOffset={12} collisionPadding={10} className="max-w-xs">
-                        <p>Attempts are shared across your team. Any team member's attempt counts towards the total.</p>
+                      <TooltipContent
+                        side="top"
+                        sideOffset={12}
+                        collisionPadding={10}
+                        className="max-w-xs"
+                      >
+                        <p>
+                          Attempts are shared across your team. Any team member's attempt counts
+                          towards the total.
+                        </p>
                       </TooltipContent>
                     </Tooltip>
                   </TooltipProvider>
@@ -813,19 +906,29 @@ export function Clue() {
               <div className=" space-y-2 w-full">
                 {!capturedImage ? (
                   // Show only Capture Image button when no image is captured
-                  <Button
-                    type="button"
-                    variant={getButtonVariant(huntType, location, capturedImage, verificationState)}
-                    size="lg"
-                    onClick={openCamera}
-                    className={cn(
-                      'w-full transition-colors duration-300',
-                      getButtonStyles(huntType, location, verificationState)
-                    )}
-                    disabled={verificationState === 'verifying' || verificationState === 'success'}
-                  >
-                    Take a picture
-                  </Button>
+                  <div className="flex gap-2">
+                    <Button
+                      type="button"
+                      variant={getButtonVariant(
+                        huntType,
+                        location,
+                        capturedImage,
+                        verificationState
+                      )}
+                      size="lg"
+                      onClick={openCamera}
+                      className={cn(
+                        'w-full transition-colors duration-300',
+                        getButtonStyles(huntType, location, verificationState)
+                      )}
+                      disabled={
+                        verificationState === 'verifying' || verificationState === 'success'
+                        || isRedirecting || isSyncing || isSkipping
+                      }
+                    >
+                      Take a picture
+                    </Button>
+                  </div>
                 ) : (
                   // Show image preview and two buttons side by side when image is captured
                   <>
@@ -848,6 +951,7 @@ export function Clue() {
                           className="w-full"
                           disabled={
                             verificationState === 'verifying' || verificationState === 'success'
+                            || isRedirecting || isSyncing || isSkipping
                           }
                         >
                           Retry
@@ -855,11 +959,7 @@ export function Clue() {
                       </div>
                       <form onSubmit={handleVerify} className="flex-1">
                         <Button
-                          key={
-                            verificationState === 'error'
-                              ? `result-${resultKey}`
-                              : undefined
-                          }
+                          key={verificationState === 'error' ? `result-${resultKey}` : undefined}
                           type="submit"
                           variant={getButtonVariant(
                             huntType,
@@ -876,7 +976,7 @@ export function Clue() {
                           disabled={
                             verificationState === 'verifying' ||
                             verificationState === 'success' ||
-                            isRedirecting
+                            isRedirecting || isSyncing || isSkipping
                           }
                         >
                           {verificationState === 'success' && <BsCheckCircle className="mr-2" />}
@@ -893,11 +993,7 @@ export function Clue() {
               // Geolocation hunt - show verify button as before
               <form onSubmit={handleVerify} className="w-full">
                 <Button
-                      key={
-                        verificationState === 'error'
-                          ? `result-${resultKey}`
-                          : undefined
-                      }
+                  key={verificationState === 'error' ? `result-${resultKey}` : undefined}
                   type="submit"
                   variant={getButtonVariant(huntType, location, capturedImage, verificationState)}
                   size="lg"
@@ -910,7 +1006,7 @@ export function Clue() {
                     !location ||
                     verificationState === 'verifying' ||
                     verificationState === 'success' ||
-                    isRedirecting
+                    isRedirecting || isSyncing || isSkipping
                   }
                 >
                   {verificationState === 'success' && <BsCheckCircle className="mr-2" />}
@@ -960,6 +1056,8 @@ export function Clue() {
             </div>
           </DialogContent>
         </Dialog>
+
+        {skipDialog}
       </div>
     </div>
   );

--- a/frontend/src/hooks/useProfileData.ts
+++ b/frontend/src/hooks/useProfileData.ts
@@ -286,7 +286,7 @@ export function useProfileData({
       huntName: string;
       clueIndex: number;
       attemptNumber: number;
-      type: 'retry' | 'solve';
+      type: 'retry' | 'solve' | 'skip';
       attestationId: string;
       timestamp: number;
     }> = [];
@@ -302,7 +302,7 @@ export function useProfileData({
       const huntName = huntsById.get(huntId) ?? `Hunt #${huntId}`;
       for (const clue of response.clues) {
         clue.attempts.forEach((entry, index) => {
-          if (mode === 'clues' && entry.type !== 'solve') return;
+          if (mode === 'clues' && entry.type !== 'solve' && entry.type !== 'skip') return;
           entries.push({
             huntId,
             huntName,

--- a/frontend/src/types/hunt.ts
+++ b/frontend/src/types/hunt.ts
@@ -6,6 +6,13 @@ export const HUNT_TYPE = {
 
 export type HuntType = typeof HUNT_TYPE.GEO_LOCATION | typeof HUNT_TYPE.IMAGE;
 
+export const CLUE_STATUS = {
+  SOLVED: "solved",
+  SKIPPED: "skipped",
+} as const;
+
+export type ClueStatus = typeof CLUE_STATUS[keyof typeof CLUE_STATUS];
+
 // Helper function to convert enum value (0 or 1) to HuntType string
 export function enumToHuntType(enumValue: number | bigint): HuntType {
   return Number(enumValue) === 1 ? HUNT_TYPE.IMAGE : HUNT_TYPE.GEO_LOCATION;

--- a/frontend/src/types/ui.ts
+++ b/frontend/src/types/ui.ts
@@ -72,7 +72,7 @@ export const textColorClasses = {
 
 export interface AttestationEntry {
   clueIndex: number;
-  type: "retry" | "solve";
+  type: "retry" | "solve" | "skip";
   attemptCount: number;
   attestationId: string;
   timestamp: number;

--- a/frontend/src/utils/progressUtils.ts
+++ b/frontend/src/utils/progressUtils.ts
@@ -12,6 +12,67 @@ export interface ProgressData {
   message?: string;
 }
 
+export async function calculateTimeTaken(params: {
+  huntId: number;
+  teamIdentifier: string;
+  currentClue: number;
+  totalClues: number;
+  chainId: string | number;
+  contractAddress: string;
+}): Promise<number> {
+  const { huntId, teamIdentifier, currentClue, totalClues, chainId, contractAddress } = params;
+
+  const currentTimestamp = Math.floor(Date.now() / 1000);
+  let startTimestamp = currentTimestamp; // fallback
+
+  if (!huntId || !teamIdentifier || !chainId || !contractAddress) {
+    return 0;
+  }
+
+  // For both first attempts and retries, we measure from when the clue became available
+  if (currentClue === 1) {
+    // For first clue, use hunt start timestamp from retry-attempts with clueIndex: 0
+    try {
+      const url = new URL(
+        `${BACKEND_URL}/hunts/${huntId}/clues/0/teams/${teamIdentifier}/attempts`
+      );
+      url.searchParams.set('chainId', chainId.toString());
+      url.searchParams.set('contractAddress', contractAddress);
+
+      const huntStartResponse = await fetch(url.toString());
+      if (huntStartResponse.ok) {
+        const huntStartData = await huntStartResponse.json();
+        if (huntStartData.firstAttemptTimestamp) {
+          startTimestamp = huntStartData.firstAttemptTimestamp;
+        }
+      }
+    } catch (error) {
+      console.error('Error fetching hunt start timestamp:', (error as Error)?.message);
+    }
+  } else {
+    // For other clues, use previous clue completion timestamp from progress endpoint
+    try {
+      const progressUrl = new URL(`${BACKEND_URL}/hunts/${huntId}/teams/${teamIdentifier}/progress`);
+      progressUrl.searchParams.set('chainId', chainId.toString());
+      progressUrl.searchParams.set('contractAddress', contractAddress);
+      progressUrl.searchParams.set('totalClues', totalClues.toString());
+
+      const progressResponse = await fetch(progressUrl.toString());
+      if (progressResponse.ok) {
+        const progressData = await progressResponse.json();
+        const prevClueIndex = currentClue - 1;
+        if (progressData.solvedClues && progressData.solvedClues[prevClueIndex]) {
+          startTimestamp = progressData.solvedClues[prevClueIndex].solveTimestamp;
+        }
+      }
+    } catch (error) {
+      console.error('Error fetching previous clue solve timestamp:', (error as Error)?.message);
+    }
+  }
+
+  return Math.max(0, currentTimestamp - startTimestamp);
+}
+
 /**
  * Fetch progress data for a team/individual in a hunt
  */
@@ -255,7 +316,7 @@ export async function validateClueAccess(
       } else {
         // Navigate to next clue
         navigate(`/hunt/${huntId}/clue/${targetClue}`);
-        toast.info(`This clue has already been solved! Redirecting to clue ${targetClue}...`);
+        toast.info(`This clue has already been completed! Redirecting to clue ${targetClue}...`);
       }
       return false;
     }


### PR DESCRIPTION
## Changes

- Earlier users get locked out if they exhaust the number of attempts in any given clue.
- This adds support for skipping clues, allowing users to continue playing where these are no longer counted towards their score.
- This was made possible by adding a status field to the clue solve schema (skipped or solved)
- Enhanced leaderboard calculations to exclude skipped clues from scoring.
- Modified the attestation timeline to reflect skipped clues appropriately.
- Updated frontend components to handle and display skipped clues, including a confirmation dialog for skipping.
- Also updated the attestation timeline to not show the last retry which corresponds to the solved clue as well.
- Little bit of a design change at the clue header.
- Added tests to ensure correct behavior for skipped clues in leaderboard and attestation timeline.

## Screenshots

| Clue | Skip confirmation dialog |
| --- | --- |
| <img width="300" alt="Screenshot from 2026-03-19 19-13-00" src="https://github.com/user-attachments/assets/972c3349-3b65-4b8a-8dd9-e32f2e02dd0e" /> | <img width="300" alt="Screenshot from 2026-03-19 19-13-12" src="https://github.com/user-attachments/assets/2cb6120c-1468-44ca-b7a9-21eeec33beaa" /> |



Closes #265 